### PR TITLE
Set only @temple.edu can register

### DIFF
--- a/frontend/src/pages/GoogleSignupPage.jsx
+++ b/frontend/src/pages/GoogleSignupPage.jsx
@@ -19,6 +19,12 @@ const GoogleSignupPage = () => {
       const decoded = jwtDecode(credential);
       const email = decoded.email;
 
+    
+    if (!email.endsWith("@temple.edu")) {
+      setError("Only @temple.edu email addresses can register.");
+      return;
+    }
+
       // Check if the email already exists in the database
       const emailExists = await checkEmailExists(email);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced additional validation for email addresses during Google sign-up, allowing only "@temple.edu" addresses.
	- Added user-friendly error messaging for invalid email submissions. 

- **Bug Fixes**
	- Enhanced error handling pathways to improve user experience during registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->